### PR TITLE
Afwu patch fix goscan undefined

### DIFF
--- a/lib/Smuggling/CheckSmuggling.go
+++ b/lib/Smuggling/CheckSmuggling.go
@@ -34,10 +34,10 @@ func checkSmuggling4Poc(ClTePayload *[]string, nTimes int, r1 *Smuggling, r *soc
 			// send result
 			util.SendAnyData(&util.SimpleVulResult{
 				Url:     r.UrlPath,
-				VulKind: string(util.goscan),
+				VulKind: string(util.Goscan),
 				VulType: (*r1).GetVulType(),
 				Payload: x,
-			}, util.goscan)
+			}, util.Goscan)
 			break
 		}
 	}

--- a/lib/util/HoneypotDetection.go
+++ b/lib/util/HoneypotDetection.go
@@ -21,7 +21,7 @@ var ipCIDS = regexp.MustCompile("^(\\d+\\.){3}\\d+\\/\\d+$")
 func CheckHoneyportDetection4HeaderServer(server, szUrl string) bool {
 	if 50 < len(server) || 3 < len(strings.Split(server, ",")) {
 		hdCache.Store(szUrl, true)
-		SendLog(szUrl, string(goscan), "Honeypot found", "")
+		SendLog(szUrl, string(Goscan), "Honeypot found", "")
 		return true
 	}
 	return false

--- a/lib/util/log.go
+++ b/lib/util/log.go
@@ -26,12 +26,12 @@ var Output = ""
 func SendLog(szUrl, szVulType, Msg, Payload string) {
 	v := &SimpleVulResult{
 		Url:     szUrl,
-		VulKind: string(goscan),
+		VulKind: string(Goscan),
 		VulType: szVulType,
 		Payload: Payload,
 		Msg:     strings.TrimSpace(Msg) + " " + szVulType,
 	}
-	SendAnyData(v, goscan)
+	SendAnyData(v, Goscan)
 	writeoutput(v)
 }
 

--- a/lib/util/sv2es.go
+++ b/lib/util/sv2es.go
@@ -24,7 +24,7 @@ const (
 	Httpx     ESaveType = "httpx"
 	Hydra     ESaveType = "hydra"
 	Nmap      ESaveType = "nmap"
-	goscan    ESaveType = "goscan"
+	Goscan    ESaveType = "goscan"
 	Subfinder ESaveType = "subfinder"
 )
 

--- a/pocs_go/go_poc_check.go
+++ b/pocs_go/go_poc_check.go
@@ -301,7 +301,7 @@ func POCcheck(wappalyzertechnologies []string, URL string, finalURL string, chec
 	}
 	// 发送结果
 	if 0 < len(technologies) {
-		util.SendAnyData(&map[string]interface{}{"Urls": []string{URL, finalURL}, "technologies": technologies}, util.goscan)
+		util.SendAnyData(&map[string]interface{}{"Urls": []string{URL, finalURL}, "technologies": technologies}, util.Goscan)
 	}
 	return technologies
 }

--- a/pocs_go/ms/ms17010.go
+++ b/pocs_go/ms/ms17010.go
@@ -125,7 +125,7 @@ func MS17010(ip string, timeout time.Duration) {
 		if reply[34] == 0x51 {
 			// CVE-2017-0143	CVE-2017-0144	CVE-2017-0145	CVE-2017-0146	CVE-2017-0147	CVE-2017-0148
 			s001 := fmt.Sprintf("ms17-010:DOUBLEPULSAR SMB IMPLANT in %s\n", ip)
-			util.SendAnyData(&s001, util.goscan)
+			util.SendAnyData(&s001, util.Goscan)
 			fmt.Printf("DOUBLEPULSAR SMB IMPLANT in %s\n", ip)
 		}
 


### PR DESCRIPTION
lib/util/sv2es.go 中的 goscan 未导出，导致编译时报错 goscan undefined。
此PR修复了lib/util/sv2es.go中goscan的定义和以下几处文件中对goscan的引用
```
lib/Smuggling/CheckSmuggling.go
lib/util/HoneypotDetection.go
lib/util/log.go
pocs_go/go_poc_check.go
pocs_go/ms/ms17010.go
```